### PR TITLE
fix search input not focused on page open

### DIFF
--- a/src/Aria/Features/Browser/Search/SearchPage.cs
+++ b/src/Aria/Features/Browser/Search/SearchPage.cs
@@ -48,6 +48,12 @@ public partial class SearchPage
 
     partial void Initialize()
     {
+        OnMap += (s, e) => GLib.Functions.IdleAdd(0, () =>
+        {
+            _searchEntry.GrabFocus();
+            return false;
+        });
+
         _searchEntry.OnSearchChanged += SearchEntryOnOnSearchChanged;
         _searchEntry.OnStopSearch += SearchEntryOnOnStopSearch;
         


### PR DESCRIPTION
The search input is now automatically focused when navigating to the search screen.


![focus-on-search-bar](https://github.com/user-attachments/assets/3af4fd21-e8c8-44ae-8c5b-039d8ae76f18)
